### PR TITLE
frontend: run tests on phantomjs

### DIFF
--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -18,10 +18,10 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
 
     plugins: [
-      'karma-chrome-launcher',
+      'karma-phantomjs-launcher',
       'karma-jasmine'
     ]
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "http-server": "^0.9.0",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
-    "karma-chrome-launcher": "^0.2.3",
-    "karma-jasmine": "^0.3.8"
+    "karma-jasmine": "^0.3.8",
+    "karma-phantomjs-launcher": "^1.0.2"
   },
   "scripts": {
     "test": "karma start karma.conf.js",


### PR DESCRIPTION
Phantomjs is now used for running of unit tests.

Fixes #11