### PR TITLE
frontend: use es6 with babel and run tests

### DIFF
--- a/frontend/app/app.spec.js
+++ b/frontend/app/app.spec.js
@@ -1,5 +1,5 @@
 describe('Routing', function() {
-    beforeEach(module('bankApp'));
+    beforeEach(angular.mock.module('bankApp'));
 
     it('Should map routes to controllers', function() {
         inject(function($route) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,3 +1,5 @@
+import angular from 'angular'
+
 /**
  * `require` all modules in the given webpack context
  */

--- a/frontend/index.spec.js
+++ b/frontend/index.spec.js
@@ -1,0 +1,26 @@
+import angular from 'angular'
+import angularRoute from 'angular-route'
+import mocks from 'angular-mocks/angular-mocks'
+
+/*
+ * The Global libraries used by the application as globals
+ */
+window.$ = window.jQuery = require('jquery')
+window.angular = require('exports?window.angular!angular')
+
+/**
+ * `require` all modules in the given webpack context
+ */
+function requireAll(context) {
+  context.keys().forEach(context);
+}
+
+/*
+ * All sources need to be included till they start to use the ES6 modules.
+ */
+requireAll(require.context('./app', true, /^(?!.*(spec.js$|e2e.js|test.js)).*\.js$/));
+
+/*
+ * All test sources
+ */
+requireAll(require.context('./app', true, /\.spec.js$/));

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,29 +1,70 @@
-//jshint strict: false
+// Karma configuration
+var webpackConfig = require('./webpack.config.js');
+const commonsChunkPluginIndex = webpackConfig.plugins.findIndex(plugin => plugin.chunkNames);
+webpackConfig.plugins.splice(commonsChunkPluginIndex, 1);
+
 module.exports = function(config) {
   config.set({
+    webpack: webpackConfig,
+    
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
 
-    basePath: './app',
-
-    files: [
-      'bower_components/angular/angular.js',
-      'bower_components/angular-resource/angular-resource.js',
-      'bower_components/angular-route/angular-route.js',
-      'bower_components/angular-mocks/angular-mocks.js',
-      '*!(.spec).js',
-      '!(bower_components)/**/*!(.spec).js',
-      '**/*.spec.js'
-    ],
-
-    autoWatch: true,
-
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['jasmine'],
 
+
+    // list of files / patterns to load in the browser
+    files: [
+      './index.spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      './index.spec.js': ['webpack'],
+      'src/**/*.spec.js': ['webpack']
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS'],
 
-    plugins: [
-      'karma-phantomjs-launcher',
-      'karma-jasmine'
-    ]
 
-  });
-};
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,15 +4,23 @@
   "description": "Bank training project.",
   "devDependencies": {
     "angular": "^1.6.1",
+    "angular-mocks": "^1.6.1",
     "angular-route": "^1.6.1",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.18.0",
     "bower": "^1.7.7",
+    "copy-webpack-plugin": "^4.0.1",
+    "exports-loader": "^0.6.3",
     "http-server": "^0.9.0",
     "jasmine-core": "^2.4.1",
     "jquery": "^3.1.1",
     "karma": "^0.13.22",
     "karma-jasmine": "^0.3.8",
     "karma-phantomjs-launcher": "^1.0.2",
-    "webpack": "1.14.0"
+    "karma-webpack": "^1.8.1",
+    "ng-cache-loader": "0.0.22",
+    "webpack": "^1.14.0"
   },
   "scripts": {
     "test": "karma start karma.conf.js",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -21,6 +21,14 @@ module.exports = {
   module: {
     loaders: [
       {
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015']
+        }
+      },
+      {
         test: /\.css$/,
         loader: "css-loader",
         options: { relativeUrls: false }


### PR DESCRIPTION
webpack is now using babel to transpile existing sources which was performed by the following changes:
 * bower_components folder is no longer used
 * babel-loader is added as loader in webpack
 * karma configuration is changed related latest changes