### PR TITLE
frontend: move transactions history controller

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -14,3 +14,10 @@ app.config(function($routeProvider, $locationProvider) {
 
     $locationProvider.html5Mode(true);
 });
+
+app.controller('TransactionsHistoryCtrl', function($scope, $http) {
+    $http.get("/history")
+        .then(function(response) {
+          $scope.transactions = response.data;
+    });
+});

--- a/frontend/app/app.test.js
+++ b/frontend/app/app.test.js
@@ -1,7 +1,6 @@
 var app = angular.module('bankAppTest', ['bankApp', 'ngMockE2E']);
 
 app.run(function($httpBackend) {
-
     var regPath = /^view\//;
 
     var transactions = [
@@ -27,11 +26,4 @@ app.run(function($httpBackend) {
 
     $httpBackend.whenGET('/history').respond(transactions);
     $httpBackend.whenGET(regPath).passThrough();
-});
-
-app.controller('Ctrl', function($scope, $http) {
-    $http.get("/history")
-        .then(function(response) {
-          $scope.transactions = response.data;
-    });
 });

--- a/frontend/app/view/transaction_history_page.view.html
+++ b/frontend/app/view/transaction_history_page.view.html
@@ -1,4 +1,4 @@
-<div class="container" ng-controller="Ctrl">
+<div class="container" ng-controller="TransactionsHistoryCtrl">
     <h2>Personal transactions:</h2>
     <table class="table table-hover">
         <thead>


### PR DESCRIPTION
The "Ctrl" is now moved in app.js as it's used in the production code. The name is changed to TransactionsHistoryCtrl which properly indicates the intention of the controller.