### PR TITLE
frontend: show line numbers when executing tests

### DIFF
--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -2,6 +2,7 @@
 var webpackConfig = require('./webpack.config.js');
 const commonsChunkPluginIndex = webpackConfig.plugins.findIndex(plugin => plugin.chunkNames);
 webpackConfig.plugins.splice(commonsChunkPluginIndex, 1);
+webpackConfig.devtool = 'inline-source-map';
 
 module.exports = function(config) {
   config.set({
@@ -29,8 +30,8 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      './index.spec.js': ['webpack'],
-      'src/**/*.spec.js': ['webpack']
+      './index.spec.js': ['webpack', 'sourcemap'],
+      'src/**/*.spec.js': ['webpack', 'sourcemap']
     },
 
     // test results reporter to use

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "karma": "^0.13.22",
     "karma-jasmine": "^0.3.8",
     "karma-phantomjs-launcher": "^1.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.1",
     "ng-cache-loader": "0.0.22",
     "webpack": "^1.14.0"


### PR DESCRIPTION
sourcemap loader is now used during the build which allows showing of correct line numbers when test fails.

```
~/bank-with-angularjs/frontend/index.spec.js:48082:41
<- webpack:///app/app.spec.js:43:40
```