### PR TITLE
frontend: added missing dependencies on style and css loaders

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,8 @@
   "author": "clouway",
   "license": "BSD",
   "dependencies": {
-    "express": "^4.14.0"
+    "css-loader": "^0.26.1",
+    "express": "^4.14.0",
+    "style-loader": "^0.13.1"
   }
 }


### PR DESCRIPTION
Added the missing dependencies for style-loader and css-loader, now contributors won't face error when trying to bundle the frontend.

Fixes #41