### PR TITLE
frontend: changed npm start script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "test": "karma start karma.conf.js",
-    "start": "node express.js",
+    "start": "webpack-dev-server -d --config webpack.config.js --content-base build/",
     "build:dev": "NODE_ENV=development webpack --config webpack.config.js",
     "build:production": "NODE_ENV=production webpack --config webpack.config.js"
   },


### PR DESCRIPTION
Changed the npm start script, now it will start the webpack-dev-server since we no longer use the express server.