### PR TITLE
frontend: LogoutCtrl fix

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -95,11 +95,11 @@ app.controller('HomePageCtrl', function($scope, $http) {
   };
 });
 
-app.controller('LogoutCtrl', function ($scope, $http) {
+app.controller('LogoutCtrl', function ($scope, $http, $location) {
 
   $scope.logout = function() {
     $http.get("/logout").then( function (response) {
-      window.location = '/login';
+      $location.path("/logout");
     });
   }
 });

--- a/frontend/app/app.test.js
+++ b/frontend/app/app.test.js
@@ -28,5 +28,6 @@ app.run(function($httpBackend) {
   $httpBackend.whenGET(regPath).passThrough();
   $httpBackend.whenGET('/v1/useraccount').respond({id: "123445", name: "John", balance: 23});
   $httpBackend.whenPOST('/v1/useraccount/changePassword').respond(200);
+  $httpBackend.whenGET('/logout').respond(200);
   // $httpBackend.whenGET('/v1/useraccount').respond(401, '');
 });


### PR DESCRIPTION
Fixed the method used to change the location after click on the logout button. The reason is that the previous method caused the PhantomJS to error, making it unavailable for tests.

Fixes #59